### PR TITLE
Provide generic x86_64 builds with matrix build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,13 +47,14 @@ jobs:
       if: ${{ env.CURRENT_VERSION != env.RELEASED_VERSION }}
       run: |
         cd linux && ../build.sh
+        mv arch/x86/boot/bzImage ./${{ matrix.image-name }}
 
     - name: Upload bzImage
       uses: actions/upload-artifact@v3
       if: ${{ env.CURRENT_VERSION != env.RELEASED_VERSION }}
       with:
         name: ${{ matrix.image-name }}
-        path: linux/arch/x86/boot/bzImage
+        path: ${{ matrix.image-name }}
 
     - id: out
       run: |
@@ -76,6 +77,7 @@ jobs:
         name:  ${{ needs.build.outputs.current_version }}
         tag_name:  ${{ needs.build.outputs.current_version }}
         files: |
-          release_images/*
+          release_images/*/*
         token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
         generate_release_notes: true
+        fail_on_unmatched_files: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,17 @@ jobs:
       with:
         name:  ${{ needs.build.outputs.current_version }}
         tag_name:  ${{ needs.build.outputs.current_version }}
+        body: |
+          Provide builds on different archs with matrix build utility of GitHub Action.
+
+          * `bzImage` for generic-x86_64-v3
+          * `bzImage-old` for generic-x86_64-v2
+          * `bzImage-skylake` for intel skylake
+
+          To check your supported x86_64 level, see [how to check supported x86_64 level of the hardware](https://unix.stackexchange.com/questions/631217/how-do-i-check-if-my-cpu-supports-x86-64-v2?msclkid=42ca61e9aa7111ecbcab7bb1a4204357).
+          If you happen to use intel skylake chips (like me), you can choose `bzImage-skylake` for best tuning.
+          
+          **NOTE for Win11 users**: the minimum requirement of Win11 ensures generic-x86_64-v3 support, so feel free to use `bzImage`.
         files: |
           release_images/*/*
         token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
       if: ${{ env.CURRENT_VERSION != env.RELEASED_VERSION }}
       run: |
         cd linux && ../build.sh
-        mv arch/x86/boot/bzImage ./${{ matrix.image-name }}
+        mv arch/x86/boot/bzImage ../${{ matrix.image-name }}
 
     - name: Upload bzImage
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,22 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     container: locietta/loia-dev-base:latest
+    outputs:
+      current_version: ${{ steps.out.outputs.current_version }}
+      release_version: ${{ steps.out.outputs.release_version }}
     
+    strategy: 
+      matrix:
+        include:
+          - arch: GENERIC_CPU2
+            image-name: bzImage-old
+          - arch: GENERIC_CPU3
+            image-name: bzImage
+          - arch: MSKYLAKE
+            image-name: bzImage-skylake
+
     steps:
     - uses: actions/checkout@v2
     
@@ -25,6 +37,8 @@ jobs:
       run: |
         git clone https://github.com/xanmod/linux.git --depth 1 linux
         cd linux && ../config.sh
+        scripts/config -e ${{ matrix.arch }}
+        clang --version
         # Load version info into env
         echo "CURRENT_VERSION=$(make kernelrelease)" | tee -a $GITHUB_ENV
         echo "RELEASED_VERSION=$(curl --silent 'https://github.com/locietta/xanmod-kernel-WSL2/releases/latest' | sed 's#.*tag/\(.*\)\".*#\1#')" | tee -a $GITHUB_ENV
@@ -38,16 +52,30 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ env.CURRENT_VERSION != env.RELEASED_VERSION }}
       with:
-        name: bzImage
+        name: ${{ matrix.image-name }}
         path: linux/arch/x86/boot/bzImage
 
+    - id: out
+      run: |
+        echo "::set-output name=current_version::${{ env.CURRENT_VERSION }}"
+        echo "::set-output name=release_version::${{ env.RELEASED_VERSION }}"
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/download-artifact@v3
+      with:
+        path: release_images/
     - name: Release
       uses: softprops/action-gh-release@v1
-      if: ${{ env.CURRENT_VERSION != env.RELEASED_VERSION }}
+      if: ${{ needs.build.outputs.current_version != needs.build.outputs.release_version }}
       with:
-        name:  ${{ env.CURRENT_VERSION }}
-        tag_name:  ${{ env.CURRENT_VERSION }}
+        name:  ${{ needs.build.outputs.current_version }}
+        tag_name:  ${{ needs.build.outputs.current_version }}
         files: |
-          linux/arch/x86/boot/bzImage
+          release_images/*
         token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
         generate_release_notes: true

--- a/config.sh
+++ b/config.sh
@@ -9,5 +9,5 @@ git apply ../0001-5.16.y-dxgkrnl-patch.patch
 cp ../wsl2_defconfig ./arch/x86/configs/wsl2_defconfig
 make LLVM=1 LLVM_IAS=1 wsl2_defconfig
 scripts/config -e LTO_CLANG_THIN
-scripts/config -e MSKYLAKE
+# scripts/config -e MSKYLAKE
 # scripts/config -e PERF_EVENTS_INTEL_UNCORE


### PR DESCRIPTION
Provide builds on different archs with matrix build utility of GitHub Action.

* `bzImage` for generic-x86_64-v3
* `bzImage-old` for generic-x86_64-v2
* `bzImage-skylake` for intel skylake