### PR TITLE
Release SHA256 signature of kernel images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install dependencies
       id: dep
       run: |
-        pacman -S --noconfirm pahole xmlto inetutils bc cpio
+        pacman -S --noconfirm pahole xmlto inetutils bc cpio jq
     #     if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
     #       echo "::set-output name=sha::$(git rev-parse ${{ github.event.pull_request.head.sha }})"
     #     else 
@@ -56,7 +56,9 @@ jobs:
         # Load version info into env
         echo "CLANG_VERSION=$(pacman -Qs clang | grep local/clang | sed "s#.*local/clang \(.*\)#\1#")" | tee -a $GITHUB_ENV
         echo "CURRENT_VERSION=$(make kernelrelease)" | tee -a $GITHUB_ENV
-        echo "RELEASED_VERSION=$(curl --silent 'https://github.com/locietta/xanmod-kernel-WSL2/releases/latest' | sed 's#.*tag/\(.*\)\".*#\1#')" | tee -a $GITHUB_ENV
+        echo "RELEASED_VERSION=$(curl -sL -H 'Authorization: token ${{ secrets.CUSTOM_GITHUB_TOKEN }}'\
+          https://api.github.com/repos/Locietta/xanmod-kernel-WSL2/releases/latest | jq -r '.tag_name')"\
+          | tee -a $GITHUB_ENV
 
     - name: Build kernel
       if: ${{ env.CURRENT_VERSION != env.RELEASED_VERSION || github.event_name == 'pull_request' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,13 +65,16 @@ jobs:
       run: |
         cd linux && ../build.sh
         mv arch/x86/boot/bzImage ../${{ matrix.image-name }}
+        cd .. && sha256sum ${{ matrix.image-name }} > ${{ matrix.image-name }}.sha256
 
     - name: Upload bzImage
       uses: actions/upload-artifact@v3
       if: ${{ env.CURRENT_VERSION != env.RELEASED_VERSION || github.event_name == 'pull_request' }}
       with:
         name: ${{ matrix.image-name }}
-        path: ${{ matrix.image-name }}
+        path: |
+          ${{ matrix.image-name }}
+          ${{ matrix.image-name }}.sha256
 
     - id: out
       run: |


### PR DESCRIPTION
This should add sha256 signature of each build as release artifact.

It also fixes a version detection bug in workflow. Since `curl --silent 'https://github.com/xxx/yyy/releases/latest'` no longer returns anything, I've switched to check released version using <del>git tags</del> github api.