### PR TITLE
Fix CI always rebuild

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
         apt-get update && apt install fakeroot build-essential libncurses-dev xz-utils libssl-dev flex libelf-dev bison zstd jq bc -y
     
     - name: Prepare source code
+      shell: bash
       run: |
         git clone https://github.com/xanmod/linux.git --depth 1 linux
         cd linux && ../config.sh


### PR DESCRIPTION
It seems like the scripts in workflow isn't ran by bash, causing problem to the logic of comparing versions. Try to fix that.

See 👉 https://github.com/Locietta/xanmod-kernel-WSL2/actions/runs/3529681320/jobs/5920912071#step:6:147

This also avoids release being overwritten, which causes scoop SHA256 check failure. (Like Locietta/sniffer#3)