### PR TITLE
[Auto Build] Switch back to Arch's LLVM distribution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: locietta/loia-dev-base:debian
+    container: locietta/loia-dev-base:latest
     outputs:
       current_version: ${{ steps.out.outputs.current_version }}
       release_version: ${{ steps.out.outputs.release_version }}
@@ -39,7 +39,7 @@ jobs:
     - name: Install dependencies
       id: dep
       run: |
-        apt-get update && apt install fakeroot build-essential libncurses-dev xz-utils libssl-dev flex libelf-dev bison zstd jq bc -y
+        pacman -S --noconfirm pahole xmlto inetutils bc cpio jq
     
     - name: Prepare source code
       shell: bash
@@ -49,10 +49,7 @@ jobs:
         scripts/config -e ${{ matrix.arch }}
 
         # Load version info into env
-        echo "CLANG_VERSION=$( \
-              clang --version | grep Debian | \
-              sed "s#Debian clang version \([0-9.]*\).*+\([a-z0-9]*\)-.*#\1@\2#" \
-              )" | tee -a $GITHUB_ENV
+        echo "CLANG_VERSION=$(pacman -Qs clang | grep local/clang | sed "s#.*local/clang \(.*\)#\1#")" | tee -a $GITHUB_ENV
         
         export CURRENT_VERSION=$(make kernelrelease)
         export RELEASED_TAG=$(curl -sL -H 'Authorization: token ${{ secrets.CUSTOM_GITHUB_TOKEN }}'\
@@ -64,7 +61,7 @@ jobs:
         echo "RELEASED_VERSION=$RELEASED_VERSION" | tee -a $GITHUB_ENV
 
         if [[ $CURRENT_VERSION != $RELEASED_VERSION || \
-              ($CURRENT_VERSION = $RELEASED_VERSION && 1 -lt "$RELEASED_MINOR") || \
+              ($CURRENT_VERSION = $RELEASED_VERSION && 1 -gt "$RELEASED_MINOR") || \
               "${{ github.event_name }}" = 'pull_request' ]]; then
           echo "REBUILD_FLAG=1" | tee -a $GITHUB_ENV
         else 
@@ -123,7 +120,7 @@ jobs:
         draft: ${{ github.event_name == 'pull_request' }}
         target_commitish: ${{ steps.fetch_commit_sha.outputs.sha }} 
         body: |
-          Cutting edge XanMod kernel for WSL2, built with Debian clang version ${{ needs.build.outputs.clang_version }} from https://apt.llvm.org.
+          Cutting edge XanMod kernel for WSL2, built with Clang ${{ needs.build.outputs.clang_version }} shipped by Arch Linux.
           Provide builds on different archs with matrix build utility of GitHub Action.
 
           * `bzImage` for generic-x86_64-v3

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Cutting edge [XanMod](https://github.com/xanmod/linux) kernel patched with [dxgkrnl](https://github.com/microsoft/WSL2-Linux-Kernel/tree/linux-msft-wsl-5.15.62.1/drivers/hv/dxgkrnl) support for **WSL2**, compiled by [clang](https://clang.llvm.org/) with ThinLTO enabled.
 
-The kernel is automatically built and released by **GitHub Action**. Latest source is fetched everyday from upstream, and the LLVM toolchain is from https://apt.llvm.org.
+The kernel is automatically built and released by **GitHub Action**. Latest source is fetched everyday from upstream, and the LLVM toolchain is obtained from [Arch Linux](https://archlinux.org/).
 
 ## Usage
 
@@ -60,7 +60,6 @@ I'll not add "microsoft" back into the version string (it's quite long now), sin
 * The Linux community for the awesome OS kernel.
 * Microsoft for WSL2 and dxgkrnl patches.
 * XanMod project for various optimizations.
-* [apt.llvm.org](https://apt.llvm.org/) for their latest Debian/Ubuntu LLVM toolchains.
 
 ## Contributing
 


### PR DESCRIPTION
Relates #28 

Local build on clang 15.0.6 says fine. Possibly a compiler bug in bleeding edge LLVM, try rolling back to see if it's helpful.