### PR TITLE
[Kernel CI] Use primary branch name in gh-actions plugins

### DIFF
--- a/.github/workflows/build-lts.yml
+++ b/.github/workflows/build-lts.yml
@@ -81,7 +81,7 @@ jobs:
         cd .. && sha256sum ${{ matrix.image-name }} > ${{ matrix.image-name }}.sha256
 
     - name: Upload bzImage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@main
       if: ${{ env.REBUILD_FLAG }}
       with:
         name: ${{ matrix.image-name }}
@@ -102,7 +102,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@main
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@main
       with:
         path: release_images/
 
@@ -117,7 +117,7 @@ jobs:
         fi
 
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@master
       if: ${{ needs.build.outputs.rebuild_flag }}
       with:
         name:  ${{ env.RELEASE_TAG }}-lts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
         cd .. && sha256sum ${{ matrix.image-name }} > ${{ matrix.image-name }}.sha256
 
     - name: Upload bzImage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@main
       if: ${{ env.REBUILD_FLAG }}
       with:
         name: ${{ matrix.image-name }}
@@ -102,7 +102,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@main
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@main
       with:
         path: release_images/
 
@@ -117,7 +117,7 @@ jobs:
         fi
 
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@master
       if: ${{ needs.build.outputs.rebuild_flag }}
       with:
         name:  ${{ env.RELEASE_TAG }}


### PR DESCRIPTION
 * We can't always check gh-actions plugins update.
 * So, Just use primary branch name in gh-actions plugins to avoid it.