### PR TITLE
[Kernel CI] Add x64v4 build & Change image naming

### DIFF
--- a/.github/workflows/build-lts.yml
+++ b/.github/workflows/build-lts.yml
@@ -24,9 +24,11 @@ jobs:
       matrix:
         include:
           - arch: GENERIC_CPU2
-            image-name: bzImage-old
+            image-name: bzImage-x64v2
           - arch: GENERIC_CPU3
-            image-name: bzImage
+            image-name: bzImage-x64v3
+          - arch: GENERIC_CPU4
+            image-name: bzImage-x64v4 
           - arch: MSKYLAKE
             image-name: bzImage-skylake
 
@@ -128,8 +130,7 @@ jobs:
           Latest XanMod LTS kernel for WSL2, built with Clang ${{ needs.build.outputs.clang_version }} shipped by [archlinuxcn](https://github.com/archlinuxcn/repo).
           Provide builds on different archs with matrix build utility of GitHub Action.
 
-          * `bzImage` for generic-x86_64-v3
-          * `bzImage-old` for generic-x86_64-v2
+          * `bzImage-x64v{2,3,4}` for generic-x86_64-v{2,3,4}
           * `bzImage-skylake` for intel skylake
 
           To check supported x86_64 level on your machine, see [how to check supported x86_64 level of the hardware](https://unix.stackexchange.com/questions/631217/how-do-i-check-if-my-cpu-supports-x86-64-v2?msclkid=42ca61e9aa7111ecbcab7bb1a4204357).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,11 @@ jobs:
       matrix:
         include:
           - arch: GENERIC_CPU2
-            image-name: bzImage-old
+            image-name: bzImage-x64v2
           - arch: GENERIC_CPU3
-            image-name: bzImage
+            image-name: bzImage-x64v3
+          - arch: GENERIC_CPU4
+            image-name: bzImage-x64v4 
           - arch: MSKYLAKE
             image-name: bzImage-skylake
 
@@ -128,8 +130,7 @@ jobs:
           Cutting edge XanMod kernel for WSL2, built with Clang ${{ needs.build.outputs.clang_version }} shipped by [archlinuxcn](https://github.com/archlinuxcn/repo).
           Provide builds on different archs with matrix build utility of GitHub Action.
 
-          * `bzImage` for generic-x86_64-v3
-          * `bzImage-old` for generic-x86_64-v2
+          * `bzImage-x64v{2,3,4}` for generic-x86_64-v{2,3,4}
           * `bzImage-skylake` for intel skylake
 
           To check supported x86_64 level on your machine, see [how to check supported x86_64 level of the hardware](https://unix.stackexchange.com/questions/631217/how-do-i-check-if-my-cpu-supports-x86-64-v2?msclkid=42ca61e9aa7111ecbcab7bb1a4204357).

--- a/README.md
+++ b/README.md
@@ -35,15 +35,18 @@ kernel = the\\path\\to\\bzImage
 
 ```bash
 scoop bucket add sniffer https://github.com/Locietta/sniffer
-scoop install xanmod-WSL2
+scoop install xanmod-WSL2 # alias to xanmod-WSL2-x64v3
 
 # other builds
-# scoop install xanmod-WSL2-old
+# scoop install xanmod-WSL2-x64v2
+# scoop install xanmod-WSL2-x64v4
 # scoop install xanmod-WSL2-skylake
 
 # LTS builds
-# scoop install xanmod-WSL2-lts
-# scoop install xanmod-WSL2-lts-old
+# scoop install xanmod-WSL2-lts # alias to xanmod-WSL2-lts-x64v3
+# scoop install xanmod-WSL2-lts-x64v2
+# scoop install xanmod-WSL2-lts-x64v3
+# scoop install xanmod-WSL2-lts-x64v4
 # scoop install xanmod-WSL2-lts-skylake
 ```
 
@@ -55,7 +58,7 @@ To update kernel for WSL2, you can use `scoop update *` if installed by scoop. O
 
 **NOTE:** To make the kernel update applied, you have to reboot WSL2 (namely, `wsl --shutdown` and open a fresh WSL2 instance).
 
-> If you are interested in how we handle install and update with scoop, see [scoop manifest](https://github.com/Locietta/sniffer/blob/master/bucket/xanmod-WSL2.json) for this kernl.
+> If you are interested in how we handle install and update with scoop, see [scoop manifest](https://github.com/Locietta/sniffer/blob/master/bucket/xanmod-WSL2.json) for this kernel.
 
 ## Miscs
 


### PR DESCRIPTION
* #53
* change the naming `bzImage-old` to `bzImage-x64v2`, `bzImage` to `bzImage-x64v3`

Also need changes at https://github.com/Locietta/sniffer.