### PR TITLE
RFC: I Shaved 63% Off My Build Time with This One Weird Trick (Developers HATE this!)

### DIFF
--- a/.github/workflows/build-lts.yml
+++ b/.github/workflows/build-lts.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install dependencies
       id: dep
       run: |
-        pacman -Syyu --noconfirm pahole xmlto inetutils bc cpio jq llvm-git llvm-libs-git clang-git lld-git
+        pacman -Syu --noconfirm pahole xmlto inetutils bc cpio jq llvm-git llvm-libs-git clang-git lld-git
 
     - name: Trust this directory
       run: git config --global --add safe.directory '*' # v2.35.3 or later

--- a/.github/workflows/build-lts.yml
+++ b/.github/workflows/build-lts.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     # manual trigger
   schedule:
-    - cron: '0 6,14,22 * * *'
+    - cron: '0 0 1 * *'
 
 env:
   IS_LTS: YES

--- a/.github/workflows/build-lts.yml
+++ b/.github/workflows/build-lts.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: '0 6,14,22 * * *'
 
+env:
+  IS_LTS: YES
+  
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
       uses: hendrikmuhs/ccache-action@v1.2
       with:
         max-size: 2048M
+        key: ${{ github.job }}-${{ matrix.arch }}
        
     - name: Prepare source code
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,8 @@ jobs:
  
     - name: Initialize ccache
       uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        max-size: 2048M
        
     - name: Prepare source code
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: '0 6,14,22 * * *'
 
+env:
+  IS_LTS: NO
+
 jobs:
   build:        
     runs-on: ubuntu-latest
@@ -39,11 +42,14 @@ jobs:
     - name: Install dependencies
       id: dep
       run: |
-        pacman -Syyu --noconfirm pahole xmlto inetutils bc cpio jq llvm-git llvm-libs-git clang-git lld-git
+        pacman -Syyu --noconfirm pahole xmlto inetutils bc cpio jq llvm-git llvm-libs-git clang-git lld-git ccache
 
     - name: Trust this directory
       run: git config --global --add safe.directory '*' # v2.35.3 or later
-    
+ 
+    - name: Initialize ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+       
     - name: Prepare source code
       shell: bash
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install dependencies
       id: dep
       run: |
-        pacman -Syyu --noconfirm pahole xmlto inetutils bc cpio jq llvm-git llvm-libs-git clang-git lld-git ccache
+        pacman -Syu --noconfirm pahole xmlto inetutils bc cpio jq llvm-git llvm-libs-git clang-git lld-git ccache
 
     - name: Trust this directory
       run: git config --global --add safe.directory '*' # v2.35.3 or later

--- a/build.sh
+++ b/build.sh
@@ -6,4 +6,8 @@ else
 fi
 # Compile
 #
-make LLVM=1 LLVM_IAS=1 -j$LOGICAL_CORES
+if [ "$IS_LTS" = "NO" ]; then
+	make CC='ccache clang -Qunused-arguments -fcolor-diagnostics' LLVM=1 LLVM_IAS=1 -j$LOGICAL_CORES
+else
+	make LLVM=1 LLVM_IAS=1 -j$LOGICAL_CORES
+fi

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,9 @@
 #
+if [ "$(cat /sys/devices/system/cpu/smt/active)" = "1" ]; then
+	export LOGICAL_CORES=$(($(nproc --all) * 2))
+else
+	export LOGICAL_CORES=$(nproc --all)
+fi
 # Compile
 #
-make LLVM=1 LLVM_IAS=1 -j$(nproc)
+make LLVM=1 LLVM_IAS=1 -j$LOGICAL_CORES

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,9 @@ fi
 # Compile
 #
 if [ "$IS_LTS" = "NO" ]; then
+	echo -e "Using $LOGICAL_CORES jobs for this non-LTS build..."
 	make CC='ccache clang -Qunused-arguments -fcolor-diagnostics' LLVM=1 LLVM_IAS=1 -j$LOGICAL_CORES
 else
+	echo -e "Using $LOGICAL_CORES jobs for this LTS build..."
 	make LLVM=1 LLVM_IAS=1 -j$LOGICAL_CORES
 fi


### PR DESCRIPTION
Hi @Locietta,

> This pull request introduces a set of patches that significantly reduce the execution time of GitHub Actions builds.

**Key Improvements:**

- Cache implementation: Caches build artifacts using ccache, resulting in a significant speedup by reusing pre-compiled objects.
- SMT awareness in CMake: Accurately accounts for the number of available threads when scheduling jobs, leading to better utilization of runners.
- Separate caches per architecture: Prevents cache poisoning by isolating caches for different architectures.
- Monthly LTS builds: Reduces runner utilization by scheduling LTS builds less frequently.

**Results:**

- Total duration reduction: Before the patchset, a normal build without SMT awareness and ccache took approximately 30 minutes and 2 seconds. After applying the changes, the build time is reduced to 11 minutes and 42 seconds, representing a 63% improvement. You can see the [detailed build run here.](https://github.com/taalojarvi/xanmod-kernel-WSL2/actions/runs/9338089789)

**Ccache Statistics:**

    Cacheable calls: 3359 / 4738 (70.89%) 
    Hits: 3353 / 3359 (99.82%) 
    Direct: 3353 / 3353 (100.0%) 
    Preprocessed: 0 / 3353 ( 0.00%) 
    Misses: 6 / 3359 ( 0.18%) 
    Uncacheable calls: 1379 / 4738 (29.11%) 

**Additional notes:**
- Ccache is not used for LTS builds to ensure that we have a clean LTS build.
- This is a sort of thank you from my side for the great work you've put into developing this project.