### PR TITLE
[Kernel Patch] Remove `unreachable()` in nf_nat_fullcone fix patch.

### DIFF
--- a/0004-nf_nat_fullcone-fix-clang-uninitialized-var-werror.patch
+++ b/0004-nf_nat_fullcone-fix-clang-uninitialized-var-werror.patch
@@ -1,14 +1,19 @@
-From ad22a7ae993d4667a73883054f7780a4f38ba904 Mon Sep 17 00:00:00 2001
+From 249e6b28c7840041e31db2721a1e733649c382e1 Mon Sep 17 00:00:00 2001
 From: Locietta <locietta@qq.com>
-Date: Sun, 7 Jan 2024 00:29:12 +0800
+Date: Wed, 19 Jun 2024 13:29:17 +0800
 Subject: [PATCH] nf_nat_fullcone: fix clang uninitialized var werror
 
+Do NOT use `unreachabe()`, which will produce empty basic blocks, causing objtool "can't
+find jump dest instruction". We could use `unreachable()` and add `-mllvm -trap-unreachable` to build flags,
+but just giving a default value is a much more straight-forward and clean solution here.
+
+Signed-off-by: Locietta <locietta@gmail.com>
 ---
  net/netfilter/nf_nat_fullcone.c | 4 ++++
  1 file changed, 4 insertions(+)
 
 diff --git a/net/netfilter/nf_nat_fullcone.c b/net/netfilter/nf_nat_fullcone.c
-index c63470fd8..9ecc7edd5 100644
+index c63470fd8..40ddb3b52 100644
 --- a/net/netfilter/nf_nat_fullcone.c
 +++ b/net/netfilter/nf_nat_fullcone.c
 @@ -1379,6 +1379,8 @@ static unsigned int nf_nat_handle_postrouting(u8 nfproto, struct sk_buff *skb, u
@@ -16,7 +21,7 @@ index c63470fd8..9ecc7edd5 100644
  		} else if (nfproto == NFPROTO_IPV6) {
  			is_src_mapping_active = src_mapping_6 != NULL && check_mapping6(src_mapping_6, net, zone);
 +		} else {
-+			unreachable();
++			is_src_mapping_active = false;
  		}
  
  		if (is_src_mapping_active) {
@@ -25,10 +30,10 @@ index c63470fd8..9ecc7edd5 100644
  				want_port =
  				    find_appropriate_port6(net, zone, original_port, &newrange->min_addr, range);
 +			} else {
-+				unreachable();
++				want_port = 0;
  			}
  
  			newrange->flags = NF_NAT_RANGE_MAP_IPS | NF_NAT_RANGE_PROTO_SPECIFIED;
 -- 
-2.43.0
+2.45.1
 


### PR DESCRIPTION
Previously, I use `unreachable()` to mark unreachable branches, so clang will not complain about variables uninitialized on unreachable branches.

It turns out that clang compilers will somehow emit empty basic blocks with `unreachable()` involved, which confuses objtool during the ThinLTO phase. It's very similar to https://lore.kernel.org/all/5913cdf4-9c8e-38f8-8914-d3b8a3565d73@kernel.org

So it's better to avoid `unreachable()` and just initialize unreachable branch anyway. This fixes boot regression on my machine.

Resolve #65 