### PR TITLE
ci: change xanmod repo location

### DIFF
--- a/.github/workflows/build-lts.yml
+++ b/.github/workflows/build-lts.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         export CURL_UA="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0"
         export VERSION_BRANCH=$(curl -s https://xanmod.org/ -A $CURL_UA | awk '/LTS/{getline; getline; print}' | grep -oP '[0-9]+\.[0-9]+')
-        git clone https://github.com/xanmod/linux.git -b $VERSION_BRANCH --depth 1 linux
+        git clone https://gitlab.com/xanmod/linux.git -b $VERSION_BRANCH --depth 1 linux
         cd linux && ../config.sh
         scripts/config -d GENERIC_CPU3 # avoid override warning for duplicate arch flags 
         scripts/config -e ${{ matrix.arch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       run: |
         export CURL_UA="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0"
         export VERSION_BRANCH=$(curl -s https://xanmod.org/ -A $CURL_UA | awk '/MAIN/{getline; getline; print}' | grep -oP '[0-9]+\.[0-9]+')
-        git clone https://github.com/xanmod/linux.git -b $VERSION_BRANCH --depth 1 linux
+        git clone https://gitlab.com/xanmod/linux.git -b $VERSION_BRANCH --depth 1 linux
         cd linux && ../config.sh
         scripts/config -d GENERIC_CPU3 # avoid override warning for duplicate arch flags 
         scripts/config -e ${{ matrix.arch }}


### PR DESCRIPTION
github's xanmod repo is archive and migrated to gitlab now.