### PR TITLE
workflows: Enable kernel rebuild on workflow_dispatch events

### DIFF
--- a/.github/workflows/build-lts.yml
+++ b/.github/workflows/build-lts.yml
@@ -70,7 +70,8 @@ jobs:
 
         if [[ $CURRENT_VERSION != $RELEASED_VERSION || \
               ($CURRENT_VERSION = $RELEASED_VERSION && 1 -gt "$RELEASED_MINOR") || \
-              "${{ github.event_name }}" = 'pull_request' ]]; then
+              "${{ github.event_name }}" = 'pull_request' || \
+              "${{ github.event_name }}" = 'workflow_dispatch' ]]; then
           echo "REBUILD_FLAG=1" | tee -a $GITHUB_ENV
         else 
           echo "REBUILD_FLAG=" | tee -a $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,8 @@ jobs:
 
         if [[ $CURRENT_VERSION != $RELEASED_VERSION || \
               ($CURRENT_VERSION = $RELEASED_VERSION && 1 -gt "$RELEASED_MINOR") || \
-              "${{ github.event_name }}" = 'pull_request' ]]; then
+              "${{ github.event_name }}" = 'pull_request' || \
+              "${{ github.event_name }}" = 'workflow_dispatch' ]]; then
           echo "REBUILD_FLAG=1" | tee -a $GITHUB_ENV
         else 
           echo "REBUILD_FLAG=" | tee -a $GITHUB_ENV


### PR DESCRIPTION
This change enhances the build workflows for both the main and LTS kernel builds by ensuring that a kernel rebuild is triggered when a workflow is manually dispatched via workflow_dispatch event.