### PR TITLE
patches: Add wcslen support and move typedefs in nls

### DIFF
--- a/patches/0006-include-Move-typedefs-in-nls-h-to-their-own-header.patch
+++ b/patches/0006-include-Move-typedefs-in-nls-h-to-their-own-header.patch
@@ -1,0 +1,83 @@
+From: Nathan Chancellor <nathan@kernel.org>
+Subject: [PATCH v3 1/2] include: Move typedefs in nls.h to their own header
+Date: Fri, 28 Mar 2025 12:26:31 -0700
+Content-Type: text/plain; charset="utf-8"
+
+In order to allow commonly included headers such as string.h to access
+typedefs such as wchar_t without running into issues with the rest of
+the NLS library, refactor the typedefs out into their own header that
+can be included in a much safer manner.
+
+Cc: stable@vger.kernel.org
+Reviewed-by: Andy Shevchenko <andy@kernel.org>
+Signed-off-by: Nathan Chancellor <nathan@kernel.org>
+---
+ include/linux/nls.h       | 19 +------------------
+ include/linux/nls_types.h | 26 ++++++++++++++++++++++++++
+ 2 files changed, 27 insertions(+), 18 deletions(-)
+
+diff --git a/include/linux/nls.h b/include/linux/nls.h
+index e0bf8367b274..3d416d1f60b6 100644
+--- a/include/linux/nls.h
++++ b/include/linux/nls.h
+@@ -3,24 +3,7 @@
+ #define _LINUX_NLS_H
+ 
+ #include <linux/init.h>
+-
+-/* Unicode has changed over the years.  Unicode code points no longer
+- * fit into 16 bits; as of Unicode 5 valid code points range from 0
+- * to 0x10ffff (17 planes, where each plane holds 65536 code points).
+- *
+- * The original decision to represent Unicode characters as 16-bit
+- * wchar_t values is now outdated.  But plane 0 still includes the
+- * most commonly used characters, so we will retain it.  The newer
+- * 32-bit unicode_t type can be used when it is necessary to
+- * represent the full Unicode character set.
+- */
+-
+-/* Plane-0 Unicode character */
+-typedef u16 wchar_t;
+-#define MAX_WCHAR_T	0xffff
+-
+-/* Arbitrary Unicode character */
+-typedef u32 unicode_t;
++#include <linux/nls_types.h>
+ 
+ struct nls_table {
+ 	const char *charset;
+diff --git a/include/linux/nls_types.h b/include/linux/nls_types.h
+new file mode 100644
+index 000000000000..9479df1016da
+--- /dev/null
++++ b/include/linux/nls_types.h
+@@ -0,0 +1,26 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++#ifndef _LINUX_NLS_TYPES_H
++#define _LINUX_NLS_TYPES_H
++
++#include <linux/types.h>
++
++/*
++ * Unicode has changed over the years.  Unicode code points no longer
++ * fit into 16 bits; as of Unicode 5 valid code points range from 0
++ * to 0x10ffff (17 planes, where each plane holds 65536 code points).
++ *
++ * The original decision to represent Unicode characters as 16-bit
++ * wchar_t values is now outdated.  But plane 0 still includes the
++ * most commonly used characters, so we will retain it.  The newer
++ * 32-bit unicode_t type can be used when it is necessary to
++ * represent the full Unicode character set.
++ */
++
++/* Plane-0 Unicode character */
++typedef u16 wchar_t;
++#define MAX_WCHAR_T	0xffff
++
++/* Arbitrary Unicode character */
++typedef u32 unicode_t;
++
++#endif /* _LINUX_NLS_TYPES_H */
+-- 
+2.49.0
+

--- a/patches/0006-lib-string-c-Add-wcslen.patch
+++ b/patches/0006-lib-string-c-Add-wcslen.patch
@@ -1,0 +1,87 @@
+From: Nathan Chancellor <nathan@kernel.org>
+Subject: [PATCH v3 2/2] lib/string.c: Add wcslen()
+Date: Fri, 28 Mar 2025 12:26:32 -0700
+Content-Type: text/plain; charset="utf-8"
+
+A recent optimization change in LLVM [1] aims to transform certain loop
+idioms into calls to strlen() or wcslen(). This change transforms the
+first while loop in UniStrcat() into a call to wcslen(), breaking the
+build when UniStrcat() gets inlined into alloc_path_with_tree_prefix():
+
+  ld.lld: error: undefined symbol: wcslen
+  >>> referenced by nls_ucs2_utils.h:54 (fs/smb/client/../../nls/nls_ucs2_utils.h:54)
+  >>>               vmlinux.o:(alloc_path_with_tree_prefix)
+  >>> referenced by nls_ucs2_utils.h:54 (fs/smb/client/../../nls/nls_ucs2_utils.h:54)
+  >>>               vmlinux.o:(alloc_path_with_tree_prefix)
+
+The kernel does not build with '-ffreestanding' (which would avoid this
+transformation) because it does want libcall optimizations in general
+and turning on '-ffreestanding' disables the majority of them. While
+'-fno-builtin-wcslen' would be more targeted at the problem, it does not
+work with LTO.
+
+Add a basic wcslen() to avoid this linkage failure. While no
+architecture or FORTIFY_SOURCE overrides this, add it to string.c
+instead of string_helpers.c so that it is built with '-ffreestanding',
+otherwise the compiler might transform it into a call to itself.
+
+Cc: stable@vger.kernel.org
+Link: https://github.com/llvm/llvm-project/commit/9694844d7e36fd5e01011ab56b64f27b867aa72d [1]
+Signed-off-by: Nathan Chancellor <nathan@kernel.org>
+---
+ include/linux/string.h |  2 ++
+ lib/string.c           | 11 +++++++++++
+ 2 files changed, 13 insertions(+)
+
+diff --git a/include/linux/string.h b/include/linux/string.h
+index 0403a4ca4c11..b000f445a2c7 100644
+--- a/include/linux/string.h
++++ b/include/linux/string.h
+@@ -10,6 +10,7 @@
+ #include <linux/stddef.h>	/* for NULL */
+ #include <linux/err.h>		/* for ERR_PTR() */
+ #include <linux/errno.h>	/* for E2BIG */
++#include <linux/nls_types.h>	/* for wchar_t */
+ #include <linux/overflow.h>	/* for check_mul_overflow() */
+ #include <linux/stdarg.h>
+ #include <uapi/linux/string.h>
+@@ -203,6 +204,7 @@ extern __kernel_size_t strlen(const char *);
+ #ifndef __HAVE_ARCH_STRNLEN
+ extern __kernel_size_t strnlen(const char *,__kernel_size_t);
+ #endif
++__kernel_size_t wcslen(const wchar_t *s);
+ #ifndef __HAVE_ARCH_STRPBRK
+ extern char * strpbrk(const char *,const char *);
+ #endif
+diff --git a/lib/string.c b/lib/string.c
+index eb4486ed40d2..2c6f8c8f4159 100644
+--- a/lib/string.c
++++ b/lib/string.c
+@@ -21,6 +21,7 @@
+ #include <linux/errno.h>
+ #include <linux/limits.h>
+ #include <linux/linkage.h>
++#include <linux/nls_types.h>
+ #include <linux/stddef.h>
+ #include <linux/string.h>
+ #include <linux/types.h>
+@@ -429,6 +430,16 @@ size_t strnlen(const char *s, size_t count)
+ EXPORT_SYMBOL(strnlen);
+ #endif
+ 
++size_t wcslen(const wchar_t *s)
++{
++	const wchar_t *sc;
++
++	for (sc = s; *sc != '\0'; ++sc)
++		/* nothing */;
++	return sc - s;
++}
++EXPORT_SYMBOL(wcslen);
++
+ #ifndef __HAVE_ARCH_STRSPN
+ /**
+  * strspn - Calculate the length of the initial substring of @s which only contain letters in @accept
+-- 
+2.49.0
+


### PR DESCRIPTION
Error log when build both stable and LTS kernels:

```
ld.lld: error: undefined symbol: wcslen
>>> referenced by nls_ucs2_utils.h:54 (fs/smb/client/../../nls/nls_ucs2_utils.h:54)
>>>               vmlinux.o:(alloc_path_with_tree_prefix)
>>> referenced by nls_ucs2_utils.h:54 (fs/smb/client/../../nls/nls_ucs2_utils.h:54)
>>>               vmlinux.o:(alloc_path_with_tree_prefix)
```

Source: https://lore.kernel.org/all/20250328-string-add-wcslen-for-llvm-opt-v3-2-a180b4c0c1c4@kernel.org/