### PR TITLE
ci: fix the handling of RELEASE_TAG

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -147,18 +147,18 @@ jobs:
 
       - id: fetch_commit_sha
         run: |
-          if [ ${{ inputs.version_suffix }} = '' ]; then
+          if [ "${{ inputs.version_suffix }}" = '' ]; then
             VERSION_SUFFIX=""
           else
             VERSION_SUFFIX="-${{ inputs.version_suffix }}"
           fi
           
-          if [ ${{ github.event_name }} = 'pull_request' ]; then
+          if [ "${{ github.event_name }}" = 'pull_request' ]; then
             echo "sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
-            echo "RELEASE_TAG=${{ needs.build.outputs.current_version }}.1$VERSION_SUFFIX-PR" | tee -a $GITHUB_ENV
+            echo "RELEASE_TAG=${{ needs.build.outputs.current_version }}.1${VERSION_SUFFIX}-PR" | tee -a $GITHUB_ENV
           else 
             echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
-            echo "RELEASE_TAG=${{ needs.build.outputs.current_version }}.1$VERSION_SUFFIX" | tee -a $GITHUB_ENV
+            echo "RELEASE_TAG=${{ needs.build.outputs.current_version }}.1${VERSION_SUFFIX}" | tee -a $GITHUB_ENV
           fi
 
       - name: Remove misc files


### PR DESCRIPTION
Fix Extra Hyphens in Release Tag Names

## Problem
When `inputs.version_suffix` is empty, GitHub Release creation fails with the error "tag_name is not a valid tag". This happens because an extra hyphen appears at the end of the generated tag name (e.g., `6.14.6-locietta-WSL2-xanmod1.1-`), causing GitHub to reject it as an invalid tag.

## Solution
1. Add quotes in bash conditional statements to ensure correct empty string comparison.
2. Use `${VERSION_SUFFIX}` instead of `$VERSION_SUFFIX` to improve variable reference handling.

This fix ensures that an extra hyphen is not appended to the tag name when no version suffix is specified.