### PR TITLE
[Kernel CI] Apply NTFS ACL on addons VHDX and ship as RAR

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -111,11 +111,11 @@ jobs:
           cd linux && ../scripts/build.sh --branch ${{ inputs.branch }}
           ../scripts/post-build.sh --name ${{ matrix.image-name }}
 
-      - name: Upload bzImage
+      - name: Upload raw build artifacts
         uses: actions/upload-artifact@main
         if: ${{ env.REBUILD_FLAG }}
         with:
-          name: ${{ matrix.image-name }}
+          name: ${{ matrix.image-name }}-raw
           include-hidden-files: true
           path: |
             ${{ matrix.image-name }}
@@ -128,9 +128,61 @@ jobs:
           echo "clang_version=${{ env.CLANG_VERSION }}" >> $GITHUB_OUTPUT
           echo "rebuild_flag=${{ env.REBUILD_FLAG }}" >> $GITHUB_OUTPUT
 
+  repack:
+    # WSL >= 2.7.1 rejects kernelModules vhdx without proper NTFS ACL (issue #153).
+    # Apply the required ACL on a Windows runner and repack with `rar -ow` so the
+    # security descriptor is preserved through the archive.
+    runs-on: windows-latest
+    needs: build
+    if: ${{ needs.build.outputs.rebuild_flag }}
+
+    strategy:
+      matrix:
+        image-name: [bzImage-x64v2, bzImage-x64v3, bzImage-skylake, bzImage-zen3]
+
+    steps:
+      - uses: actions/download-artifact@main
+        with:
+          name: ${{ matrix.image-name }}-raw
+          path: .
+
+      - name: Extract addons vhdx from 7z transit archive
+        shell: pwsh
+        run: |
+          $sevenZip = "C:\Program Files\7-Zip\7z.exe"
+          & $sevenZip x "${{ matrix.image-name }}-addons.vhdx.7z" -y
+          Remove-Item "${{ matrix.image-name }}-addons.vhdx.7z"
+
+      - name: Apply NTFS ACL to addons vhdx
+        shell: pwsh
+        run: |
+          $vhdx = "${{ matrix.image-name }}-addons.vhdx"
+          icacls $vhdx /inheritance:r `
+            /grant:r "*S-1-5-18:(F)" "*S-1-5-32-544:(F)" `
+                     "*S-1-5-32-545:(RX)" `
+                     "*S-1-15-2-1:(RX)" "*S-1-15-2-2:(RX)"
+          icacls $vhdx
+
+      - name: Install WinRAR
+        run: choco install winrar -y --no-progress
+
+      - name: Repack vhdx with rar (preserve NTFS security descriptor)
+        shell: pwsh
+        run: |
+          $rar = "C:\Program Files\WinRAR\Rar.exe"
+          & $rar a -ow -m5 -ep "${{ matrix.image-name }}-addons.vhdx.rar" "${{ matrix.image-name }}-addons.vhdx"
+
+      - name: Upload final artifacts
+        uses: actions/upload-artifact@main
+        with:
+          name: ${{ matrix.image-name }}
+          path: |
+            ${{ matrix.image-name }}
+            ${{ matrix.image-name }}-addons.vhdx.rar
+
   release:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, repack]
     permissions:
       contents: write
 

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -175,7 +175,7 @@ jobs:
       - name: Upload final artifacts
         uses: actions/upload-artifact@main
         with:
-          name: ${{ matrix.image-name }}
+          name: kernel-release-${{ matrix.image-name }}
           path: |
             ${{ matrix.image-name }}
             ${{ matrix.image-name }}-addons.vhdx.rar
@@ -193,6 +193,9 @@ jobs:
       - uses: actions/checkout@main
       - uses: actions/download-artifact@main
         with:
+          # Only pull the final repacked artifacts (bzImage + .vhdx.rar);
+          # skip the *-raw transit artifacts that still contain .vhdx.7z.
+          pattern: kernel-release-*
           path: release_images/
           merge-multiple: true
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ We recommend to run `scoop update *` instead of `scoop update xanmod-WSL2` alone
 
 ### Manual Installation
 
-It's also straightforward to manually install this kernel. For each arch, we release two files: the kernel image `bzImage` and an optional addon archive `bzImage-addons.vhdx.7z` that contains the VHDX with extra modules, headers and documentation.
+It's also straightforward to manually install this kernel. For each arch, we release two files: the kernel image `bzImage` and an optional addon archive `bzImage-addons.vhdx.rar` that contains the VHDX with extra modules, headers and documentation.
 
 The manual installation steps are as follows:
 

--- a/scripts/post-build.sh
+++ b/scripts/post-build.sh
@@ -131,7 +131,7 @@ cp README COPYING "$DOC_DIR/" 2>/dev/null || true
 # Create VHDX for Kernel Modules
 sudo ../scripts/gen_modules_vhdx.sh "$IMAGE_NAME-addons" "$KERNEL_VERSION" "${IMAGE_NAME}-addons.vhdx"
 
-# Compress the addon VHDX to reduce release and install size.
+# Compress the addon VHDX to speed up artifact transfer between CI jobs.
 7z a -mx=9 "${IMAGE_NAME}-addons.vhdx.7z" "${IMAGE_NAME}-addons.vhdx" >/dev/null
 rm -f "${IMAGE_NAME}-addons.vhdx"
 


### PR DESCRIPTION
#153.

WSL 2.7.1+ rejects the `kernelModules` vhdx when it lives under a restricted directory such as `C:\Users\<user>\` (the Scoop default install location), failing with `Wsl/Service/CreateInstance/CreateVm/HCS/E_ACCESSDENIED`.

The vhdx must carry an NTFS ACL granting:

* `SYSTEM` / `Administrators` — FullControl
* `Users` / `ALL APPLICATION PACKAGES` / `ALL RESTRICTED APPLICATION PACKAGES` — ReadAndExecute

7z does not preserve NTFS security descriptors, so on extract the vhdx inherits whatever ACL the destination directory provides. Switch the release archive to RAR (which does, via `-ow`) and bake the ACL in CI:

* Linux build job still produces `*-addons.vhdx.7z` as a transit artifact for fast inter-job transfer (kept the compression added in https://github.com/Locietta/xanmod-kernel-WSL2/commit/b6c60719f5495ccfeb3c09023c4caf125216f9a5).
* New Windows repack job (`windows-latest`, matrix per arch): extracts the transit `.7z`, applies the required ACL via `icacls /inheritance:r /grant:r ...` (using SIDs to avoid locale issues), then repacks with `rar a -ow` so the security descriptor lands inside the archive.
* Final release artifact is now `bzImage-*-addons.vhdx.rar` instead of `.vhdx.7z`. README updated accordingly.

**NOTE**
The companion [Locietta/sniffer](https://github.com/Locietta/sniffer) manifests also need follow-up, because scoop's default extraction method also does not perserve the NTFS security descriptors from rar.